### PR TITLE
Potential fix for code scanning alert no. 26: Unsafe jQuery plugin

### DIFF
--- a/docs/assets/js/toolkit.js
+++ b/docs/assets/js/toolkit.js
@@ -4813,7 +4813,7 @@ var Stage = function ($) {
         $(document).off(Event.TOUCHMOVE);
       }
 
-      $(this._config.hiddenElements).addClass(ClassName.HIDDEN);
+      $($.find(this._config.hiddenElements)).addClass(ClassName.HIDDEN);
 
       $(this._element).removeClass(ClassName.STAGE_OPEN).css({
         '-webkit-transition': '',
@@ -4847,7 +4847,7 @@ var Stage = function ($) {
         });
       }
 
-      $(this._config.hiddenElements).removeClass(ClassName.HIDDEN);
+      $($.find(this._config.hiddenElements)).removeClass(ClassName.HIDDEN);
 
       $(window).one(Event.KEYDOWN, $.proxy(function (e) {
         e.which == 27 && this.close();


### PR DESCRIPTION
Potential fix for [https://github.com/cozyglow/cozy-glow-theme/security/code-scanning/26](https://github.com/cozyglow/cozy-glow-theme/security/code-scanning/26)

The safest fix is to stop passing `hiddenElements` to the jQuery constructor and instead resolve it strictly as a selector via `$.find`, which does not parse HTML strings. This preserves intended functionality (selecting existing DOM elements to hide/show) while preventing HTML interpretation of untrusted input.

In `docs/assets/js/toolkit.js`, update both places where `this._config.hiddenElements` is used (`_complete` and `open`) from:

- `$(this._config.hiddenElements).addClass(...)`
- `$(this._config.hiddenElements).removeClass(...)`

to:

- `$($.find(this._config.hiddenElements)).addClass(...)`
- `$($.find(this._config.hiddenElements)).removeClass(...)`

No new imports or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
